### PR TITLE
docs and examples update for joss

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,27 +7,26 @@ PyFlowline: a mesh-independent river network generator for hydrologic models.
 PyFlowline is mesh independent, meaning you can apply it to both structured (e.g., traditional rectangle mesh, latitude-longitude, hexagon) and unstructured mesh systems (e.g., Triangulated Irregular Network (TIN) mesh and Model for Prediction Across Scales (MPAS) mesh).
 
 This package generates the mesh cell-based conceptual river networks using the following steps:
-1. `Flowline simplification`: PyFlowline checks the vector dataset and corrects undesired flowlines, such as braided rivers. 
-2. `Mesh generation`: PyFlowline generates structured meshes (e.g., rectangle, hexagon) or imports user-provided unstructured meshes into the PyFlowline-compatible GEOJSON format.
-3. `Topological relationship reconstruction`: PyFlowline reconstructs the topological relationship using the mesh and flowline intersections. 
 
+1. `Flowline simplification`: PyFlowline checks the vector dataset and corrects undesired flowlines, such as braided rivers.
+2. `Mesh generation`: PyFlowline generates structured meshes (e.g., rectangle, hexagon) or imports user-provided unstructured meshes into the PyFlowline-compatible GEOJSON format.
+3. `Topological relationship reconstruction`: PyFlowline reconstructs the topological relationship using the mesh and flowline intersections.
 
 ### Quickstart
 
-https://pyflowline.readthedocs.io/en/latest/quickstart.html
+Please refer to the [quickstart documentation](https://pyflowline.readthedocs.io/en/latest/quickstart.html) for details on how to get started using the PyFlowline package.
 
 ### Installation
 
-Please refer to the official documentation (https://pyflowline.readthedocs.io/) for details on how to install the PyFlowline package.
+Please refer to the [official documentation](https://pyflowline.readthedocs.io/) for details on how to install the PyFlowline package.
 
 ### Application
 
-We provide several examples in the `examples` folder to demonstrate the model capability.
-
+We provide several examples in the `examples` folder to demonstrate the model capability. We also recommend starting with the `notebooks/mpas_example.ipynb` notebook, after following the Quickstart and Installation instructions.
 
 ### Acknowledgment
 
-This work was supported by the Earth System Model Development program areas of the U.S. Department of Energy, Office of Science, Office of Biological and Environmental Research as part of the multi-program, collaborative Integrated Coastal Modeling (ICoM) project and the Interdisciplinary Research for Arctic Coastal Environments (InteRFACE) project. 
+This work was supported by the Earth System Model Development program areas of the U.S. Department of Energy, Office of Science, Office of Biological and Environmental Research as part of the multi-program, collaborative Integrated Coastal Modeling (ICoM) project and the Interdisciplinary Research for Arctic Coastal Environments (InteRFACE) project.
 
 ### License
 
@@ -51,10 +50,3 @@ Several publications describe the algorithms used in `PyFlowline` in detail. If 
 https://doi.org/10.5281/zenodo.6407299
 
 * Liao, C., Zhou, T., Xu, D., Cooper, M. G., Engwirda, D., Li, H.-Y., & Leung, L. R. (2023). Topological relationship-based flow direction modeling: Mesh-independent river networks representation. Journal of Advances in Modeling Earth Systems, 15, e2022MS003089. https://doi.org/10.1029/2022MS003089
-
-
-
-
-
-    
-

--- a/docs/source/application/application.rst
+++ b/docs/source/application/application.rst
@@ -33,7 +33,7 @@ The `pyflowline_read_model_configuration_file` function reads in a JSON configur
 Step 2
 ================
 
-The script setups some paths, which should be adjusted based on a real case.
+The script sets up some paths, which should be adjusted based on a real case and your local directory structure.
 
 ::   
     
@@ -41,7 +41,7 @@ The script setups some paths, which should be adjusted based on a real case.
     sPath_data = realpath( sPath_parent +  '/data/susquehanna' )
     sWorkspace_input =  str(Path(sPath_data)  /  'input')
     sWorkspace_output=  str(Path(sPath_data)  /  'output')
-    sWorkspace_output=  '/compyfs/liao313/04model/pyflowline/susquehanna'
+    sWorkspace_output=  '/full/path/to/pyflowline/data/susquehanna/output'
 
 ================
 Step 3

--- a/docs/source/data/data.rst
+++ b/docs/source/data/data.rst
@@ -49,7 +49,7 @@ Inputs
 ==============================
 
 
-PyFlowline uses two configuration files to manage all the input information. Within this configuration file, it stores major model input parameters paths to input files. 
+PyFlowline uses two configuration files to manage all the input information. Within this configuration file, it stores major model input parameters and paths to input files. 
 
 These two configuration files have a parent-child relationship:
 1. The parent configuration file stores parameters for the whole domain, and

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -20,12 +20,17 @@ Frequently Asked Questions
    Anaconda:
 
    `export PROJ_LIB=/people/user/.conda/envs/hexwatershed/share/proj`
+   `export PROJ_LIB=$HOME/opt/anaconda3/envs/pyflowline/share/proj`
 
    Miniconda:
 
    `export PROJ_LIB=/opt/miniconda3/envs/hexwatershed/share/proj`
 
-4. What if my model doesn't produce the correct or expected answer?
+4. I am getting errors using the plot functions
+
+   If you receive an error related to `GeoAxesSubplot`, make sure you have cartopy version 0.21.0 installed in your environment. Optionally, downgrade matplotlib to 3.5.2. 
+
+5. What if my model doesn't produce the correct or expected answer?
    
    Answer: There are several hidden assumptions within the workflow. For example, if you provide the DEM and river network for two different regions, the program won't be able to tell you that. A visual inspection of your data is important.
    

--- a/docs/source/installation/installation.rst
+++ b/docs/source/installation/installation.rst
@@ -15,14 +15,14 @@ Two different options are provided below.
 Requirements
 ************
 
-We recommend that users to use the Conda system to install the PyFlowline package.
+We recommend to use the Conda system to install the PyFlowline package.
 
 Conda can be installed on Linux, MacOS, and Windows systems. 
 Please refer to the conda website for details on how to install Conda: 
 https://docs.conda.io/en/latest/
 
-After Conda is available on your system, you can create a conda environment for your application.
-Then you use Option A or B to install PyFlowline in the newly created environment.
+After Conda is available on your system, you can create a conda environment for your application of PyFlowline.
+Then use Option A or B to install PyFlowline in the newly created environment.
 
 ==========
 Option A

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -4,12 +4,13 @@ Quickstart
 
 Users can run a PyFlowline simulation in the following steps:
 
-1. Create a new Python environment using Conda, and activate new environment
+1. Create a new Python environment using Conda, and activate the new environment.
 2. Clone the latest PyFlowline repository from https://github.com/changliao1025/pyflowline. 
 3. Install the dependency packages using conda.
-4. Download the additional large files (MPAS mesh (https://github.com/changliao1025/pyflowline/releases/tag/0.2.0)) and move them under the `data/susquehanna/input` folder.
-5. Change the `sFilename_mesh_netcdf`, `sFilename_basins`, and `sFilename_flowline_filter` to the actual paths. Other DEM data may be downloaded as needed.
-6. Open the preferred Python IDE (Visual Studio Code recommended) and run the  `examples/susquehanna/run_simulation_mpas.py` Python script. Optionally, you can also run the `notebooks/mpas_notebook.ipynb` notebook.
-7. You should produce a list of model outputs in the `data/susquehanna/output` folder or the user-specified output folder.
+4. Download the additional large MPAS mesh file `lnd_cull_mesh.nc` from https://github.com/changliao1025/pyflowline/releases/tag/0.2.0 and move it under the `data/susquehanna/input` folder.
+5. Open the `examples/susquehanna/pyflowline_susquehanna_mpas.json` file and change `sWorkspace_output` to the full path to the directory where you want to save the output (e.g. `/full/path/to/pyflowline/data/susquehanna/output`), change `"sFilename_mesh_netcdf"` to the full path to `lnd_cull_mesh.nc`, `"sFilename_mesh_boundary"` to the full path to `data/susquehanna/input/mesh_boundary_buffer.geojson`, and `"sFilename_basins"` to the full path to `examples/susquehanna/pyflowline_susquehanna_basins.json`.
+6. Open the `examples/susquehanna/pyflowline_susquehanna_basins.json` file and change `"sFilename_flowline_filter"` to the full path to `data/susquehanna/input/flowline.geojson`. Ignore the other settings in these json files for now.
+7. Open the preferred Python IDE (Visual Studio Code recommended) and run the  `examples/susquehanna/run_simulation_mpas.py` Python script. Optionally, you can also run the `notebooks/mpas_notebook.ipynb` notebook.
+8. You should produce a list of model outputs in the `data/susquehanna/output` folder or the user-specified output folder.
 
 If you encounter any issues, refer to the FAQ or submit a GitHub issue (https://github.com/changliao1025/pyflowline/issues).

--- a/examples/susquehanna/pyflowline_susquehanna_basins.json
+++ b/examples/susquehanna/pyflowline_susquehanna_basins.json
@@ -9,7 +9,7 @@
         "iFlag_disconnected": 0,
         "lBasinID": 1,
         "sFilename_dam": "/qfs/people/liao313/data/hexwatershed/susquehanna/auxiliary/ICoM_dams.csv",
-        "sFilename_flowline_filter": "/Users/liao313/workspace/python/pyflowline/data/susquehanna/input/flowline.geojson",
+        "sFilename_flowline_filter": "/Users/coop558/myprojects/python/pyflowline/data/susquehanna/input/flowline.geojson",
         "sFilename_flowline_raw": "/qfs/people/liao313/data/hexwatershed/susquehanna/vector/hydrology/allflowline.shp",
         "sFilename_flowline_topo": "/qfs/people/liao313/data/hexwatershed/susquehanna/auxiliary/flowline.csv"
         

--- a/examples/susquehanna/pyflowline_susquehanna_mpas.json
+++ b/examples/susquehanna/pyflowline_susquehanna_mpas.json
@@ -1,7 +1,7 @@
 {
     "sFilename_model_configuration": "/qfs/people/liao313/workspace/python/pyflowline/pyflowline/config/hexwatershed_susquehanna_mpas.json",
-    "sWorkspace_data": "/people/liao313/data",    
-    "sWorkspace_output": "/Users/liao313/tmp",
+    "sWorkspace_data": "/people/liao313/data",
+    "sWorkspace_output": "/Users/coop558/myprojects/python/pyflowline/data/susquehanna/output",
     "sWorkspace_project": "/hexwatershed/susquehanna",
     "sWorkspace_bin": "/people/liao313/bin",
     "sRegion": "susquehanna",
@@ -30,7 +30,7 @@
     "sMesh_type": "mpas",       
     "sFilename_spatial_reference": "/qfs/people/liao313/workspace/python/pyhexwatershed_icom/data/susquehanna/input/boundary_proj_buff.shp",
     "sFilename_dem": "/qfs/people/liao313/workspace/python/pyhexwatershed_icom/data/susquehanna/input/dem_buff_ext.tif",     
-    "sFilename_mesh_netcdf": "/Users/liao313/workspace/python/pyflowline/data/susquehanna/input/lnd_cull_mesh.nc",    
-    "sFilename_mesh_boundary": "/Users/liao313/workspace/python/pyflowline/data/susquehanna/input/mesh_boundary_buffer.geojson",
-    "sFilename_basins": "/Users/liao313/workspace/python/pyflowline/examples/susquehanna/pyflowline_susquehanna_basins.json"
+    "sFilename_mesh_netcdf": "/Users/coop558/myprojects/python/pyflowline_icom/data/susquehanna/input/lnd_cull_mesh.nc",
+    "sFilename_mesh_boundary": "/Users/coop558/myprojects/python/pyflowline/data/susquehanna/input/mesh_boundary_buffer.geojson",
+    "sFilename_basins": "/Users/coop558/myprojects/python/pyflowline/examples/susquehanna/pyflowline_susquehanna_basins.json"
 }

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,6 @@ setup(
     install_requires=REQUIRED,
     classifiers=CLASSIFY,
     extras_require={
-        'visualization': ['matplotlib', 'cartopy']
+        'visualization': ['matplotlib', 'cartopy>=0.21.0']
     }
 )


### PR DESCRIPTION
Edited documentation and README, updated cartopy dependency in setup.py, and modified configuration files to run example_mpas in my local environment.

Some additional suggestions  I did not implement:

- Instead of creating the oPyflowline object at the bottom of the pyflowline_read_model_configuration_file function, consider returning the aConfig dictionary and then pass that to flowlinecase to create the object, unless you don't want to expose the critical step of creating the oPyflowline object to users

- If lnd_cull_mesh.nc is the only file required from the tagged release, it might help to be specific about that so users don't download the entire release. For example we could include a suggestion to use `wget https://github.com/changliao1025/pyflowline/releases/download/0.2.0/lnd_cull_mesh.nc` which is how I did it

- Even though only a few paths need to be changed in the configuration file, some paths and/or files need to exist locally to avoid errors during the read configuration file step. I updated the documentation to specify the minimum number of paths that must be updated to run the example on my machine, but you might want to change the way pyflowline_read_model_configuration_file handles the different paths. Some of the errors I receive seem to be unrelated to the actual example case, but I get errors because pyflowline_read_model_configuration_file doesn't handle errors due to non-existent paths and/or files, even if they aren't used in the case setup.