### PR TITLE
Fix data.rst to correctly render input directory tree

### DIFF
--- a/docs/source/data/data.rst
+++ b/docs/source/data/data.rst
@@ -230,15 +230,16 @@ Inputs
 The following recommended workspace structure and example input files are provided to run a PyFlowline simulation. Although the repo includes example configuration files in the examples/ directory, they can be placed wherever the user prefers, as long as the paths within them point to the correct locations for input (and output) data.
 
 ::
-	data
-	└── <domain_name>
-		├── input
-		│   ├── boundary_wgs.geojson
-		│   ├── flowline.geojson
-		│   ├── pyflowline_<domain_name>_<meshtype>.json
-		│   └── pyflowline_<domain_name>_basins.json 
-		└── output 
-			└── ...
+
+    data
+    └── <domain_name>
+        ├── input
+        │   ├── boundary_wgs.geojson
+        │   ├── flowline.geojson
+        │   ├── pyflowline_<domain_name>_<meshtype>.json
+        │   └── pyflowline_<domain_name>_basins.json
+        └── output
+            └── ...
 
 ==============================
 Outputs


### PR DESCRIPTION
This is a very minor fix to data.rst. It adds a space after :: so the recommended input directory tree renders correctly.