### PR TITLE
Refactor/demos csdms

### DIFF
--- a/examples/susquehanna/run_simulation_hexagon.py
+++ b/examples/susquehanna/run_simulation_hexagon.py
@@ -1,44 +1,111 @@
 import os, sys
 from pathlib import Path
 from os.path import realpath
+from datetime import datetime
+
+#%% setup case information
+
+sMesh = 'hexagon'
+iCase_index = 1
+dResolution_meter = 50000 # mesh resolution
+sDate = datetime.now().strftime('%Y%m%d')
+
+# Temporary patch to avoid bug in mesh generation function
+iFlag_mesh_generation = False
 
 #%% set up workspace path
 sPath_parent = str(Path(__file__).parents[2]) # data is located two dir's up
 import sys
 sys.path.append(sPath_parent)
 
-from pyflowline.configuration.read_configuration_file import pyflowline_read_configuration_file
+#%% set up workspace folders
+sWorkspace_data = realpath( sPath_parent + '/data/susquehanna' )
+sWorkspace_input = str(Path(sWorkspace_data) / 'input')
+sWorkspace_output = str(Path(sWorkspace_data) / 'output')
 
-
-sPath_data = realpath( sPath_parent +  '/data/susquehanna' )
-sWorkspace_input =  str(Path(sPath_data)  /  'input')
-sWorkspace_output=  str(Path(sPath_data)  /  'output')
-
-#%% you need to update this file based on your own case study
-sFilename_configuration_in = realpath( sPath_parent +  '/data/susquehanna/input/pyflowline_susquehanna_hexagon.json' )
+#%% set the configuration file names.
+sFilename_configuration_in = realpath( sWorkspace_input + '/' + 'pyflowline_susquehanna_hexagon.json' )
 if os.path.isfile(sFilename_configuration_in):
     pass
 else:
-    print('This configuration does not exist: ', sFilename_configuration_in )
+    print(f"The model configuration does not exist: \n{sFilename_configuration_in}\n")
 
-#%% setup case information
-iCase_index = 1
-dResolution_meter = 50000
+# set the basin configuration file name
+sFilename_basins_in = realpath( sWorkspace_input + '/' + 'pyflowline_susquehanna_basins.json' )
+if os.path.isfile(sFilename_configuration_in):
+    pass
+else:
+    print(f"The basin configuration does not exist: \n{sFilename_basins_in}\n")
 
-sMesh = 'hexagon'
-sDate='20230101'
+#%% set the input data filenames
+sFilename_flowline_filter = realpath( sWorkspace_input + '/' + 'flowline.geojson' )
 
-oPyflowline = pyflowline_read_configuration_file(sFilename_configuration_in, \
-iCase_index_in=iCase_index, dResolution_meter_in=dResolution_meter, sDate_in=sDate)
+sFilename_mesh_boundary = realpath( sWorkspace_input + '/' + 'boundary_wgs.geojson' )
+
+#%% set the configuration file parameters
+
+# To change a parameter in the json configuration file, pass the configuration file filename followed by a single key-value pair. For the basin configuration file only, pass the final argument iFlag_basin_in=1. Import the function used to change the parameters.
+from pyflowline.configuration.change_json_key_value import change_json_key_value as pyflowline_change_json_key_value
+
+# Set the path to the data folder
+pyflowline_change_json_key_value(sFilename_configuration_in, 'sWorkspace_data', sWorkspace_data)
+
+# Set the path to the input folder
+pyflowline_change_json_key_value(sFilename_configuration_in, 'sWorkspace_input', sWorkspace_input)
+
+# Set the path to the output folder
+pyflowline_change_json_key_value(sFilename_configuration_in, 'sWorkspace_output', sWorkspace_output)
+
+# Set the model configuration file name
+pyflowline_change_json_key_value(sFilename_configuration_in, 'sFilename_model_configuration', sFilename_configuration_in)
+
+# Set the basin configuration file name
+pyflowline_change_json_key_value(sFilename_configuration_in, 'sFilename_basins', sFilename_basins_in)
+
+# Set the domain boundary file name
+pyflowline_change_json_key_value(sFilename_configuration_in, 'sFilename_mesh_boundary', sFilename_mesh_boundary)
+
+# pyflowline_change_json_key_value(sFilename_configuration_in, 'sFilename_spatial_reference', sFilename_mesh_boundary)
+
+# Note that a DEM can also be supplied. Set the path to the DEM with the sFilename_dem parameter. Although the DEM is not required by `pyflowline`, users will need a DEM to run `hexwatershed`. If a DEM is supplied, a boundary file is not required - the DEM boundary will be used instead. However, if a DEM is not supplied, then the model requires a domain boundary to create the mesh.
+
+# If a boundary file is used, set the iFlag_mesh_boundary flag true
+pyflowline_change_json_key_value(sFilename_configuration_in, 'iFlag_mesh_boundary', 1)
+
+# Set the path to the flowline in the basin configuration file
+pyflowline_change_json_key_value(sFilename_basins_in, 'sFilename_flowline_filter', sFilename_flowline_filter, iFlag_basin_in=1)
+
+#%% read the configuration file to create a pyflowline case
+from pyflowline.configuration.read_configuration_file import pyflowline_read_configuration_file
+oPyflowline = pyflowline_read_configuration_file(sFilename_configuration_in,iCase_index_in=iCase_index, dResolution_meter_in=dResolution_meter, sDate_in=sDate)
+
+#%% change model parameters as needed before running the model
 oPyflowline.aBasin[0].dLatitude_outlet_degree=39.462000
 oPyflowline.aBasin[0].dLongitude_outlet_degree=-76.009300
-oPyflowline.setup()
-oPyflowline.flowline_simplification()
-aCell = oPyflowline.mesh_generation()
-oPyflowline.reconstruct_topological_relationship(aCell)
-oPyflowline.export()
-iCase_index= iCase_index+1
 
-print('Finished')
+#%% run the model
+oPyflowline.pyflowline_setup()
+oPyflowline.pyflowline_flowline_simplification();
+
+#%% generate the mesh.
+
+# There is currently a bug in the mesh generation function when a boundary file is used instead of a DEM. Skip this step until that bug is fixed.
+
+if iFlag_mesh_generation is True:
+
+    aCell = oPyflowline.pyflowline_mesh_generation();
+    oPyflowline.pyflowline_reconstruct_topological_relationship(aCell)
+
+    # Export the model results for hexwatershed
+    oPyflowline.pyflowline_export()
+    oPyflowline.pyflowline_export_config_to_json()
+    iCase_index= iCase_index+1
+
+else:
+    pass
+
+# %%
+print('Finished hexagon demo.')
+print('Try opening the mesh and flowline files in QGIS for visualization.')
 
 # %%

--- a/examples/susquehanna/run_simulation_latlon.py
+++ b/examples/susquehanna/run_simulation_latlon.py
@@ -1,44 +1,109 @@
 import os, sys
 from pathlib import Path
 from os.path import realpath
+from datetime import datetime
+
+#%% setup case information
+
+sMesh = 'latlon'
+iCase_index = 3
+dResolution_meter = 50000 # mesh resolution
+sDate = datetime.now().strftime('%Y%m%d')
+
+# Temporary patch to avoid bug in mesh generation function
+iFlag_mesh_generation = False
 
 #%% set up workspace path
-sPath_parent = str(Path(__file__).parents[2]) # data is located two dir's up
 sPath_parent = str(Path(__file__).parents[2]) # data is located two dir's up
 import sys
 sys.path.append(sPath_parent)
 
-from pyflowline.configuration.pyflowline_read_configuration_file import pyflowline_read_configuration_file
+#%% set up workspace folders
+sWorkspace_data = realpath( sPath_parent + '/data/susquehanna' )
+sWorkspace_input = str(Path(sWorkspace_data) / 'input')
+sWorkspace_output = str(Path(sWorkspace_data) / 'output')
 
-sPath_data = realpath( sPath_parent +  '/data/susquehanna' )
-sWorkspace_input =  str(Path(sPath_data)  /  'input')
-sWorkspace_output=  str(Path(sPath_data)  /  'output')
-
-#%% you need to update this file based on your own case study
-sFilename_configuration_in = realpath( sPath_parent + '//data/susquehanna/input//pyflowline_susquehanna_latlon.json' )
+#%% set the configuration file names.
+sFilename_configuration_in = realpath( sWorkspace_input + '/' + 'pyflowline_susquehanna_latlon.json' )
 if os.path.isfile(sFilename_configuration_in):
     pass
 else:
-    print('This configuration does not exist: ', sFilename_configuration_in )
+    print(f"The model configuration does not exist: \n{sFilename_configuration_in}\n")
 
-#%% setup case information
-iCase_index = 3
-dResolution_meter = 50000
+# set the basin configuration file name
+sFilename_basins_in = realpath( sWorkspace_input + '/' + 'pyflowline_susquehanna_basins.json' )
+if os.path.isfile(sFilename_configuration_in):
+    pass
+else:
+    print(f"The basin configuration does not exist: \n{sFilename_basins_in}\n")
 
-sMesh = 'latlon'
-sDate='20230101'
+#%% set the input data filenames
+sFilename_flowline_filter = realpath( sWorkspace_input + '/' + 'flowline.geojson' )
 
-oPyflowline = pyflowline_read_configuration_file(sFilename_configuration_in, \
-iCase_index_in=iCase_index, dResolution_meter_in=dResolution_meter, sDate_in=sDate)
+sFilename_mesh_boundary = realpath( sWorkspace_input + '/' + 'boundary_wgs.geojson' )
 
-#%%
+#%% set the configuration file parameters
+
+# To change a parameter in the json configuration file, pass the configuration file filename followed by a single key-value pair. For the basin configuration file only, pass the final argument iFlag_basin_in=1. Import the function used to change the parameters.
+from pyflowline.configuration.change_json_key_value import change_json_key_value as pyflowline_change_json_key_value
+
+# Set the path to the data folder
+pyflowline_change_json_key_value(sFilename_configuration_in, 'sWorkspace_data', sWorkspace_data)
+
+# Set the path to the input folder
+pyflowline_change_json_key_value(sFilename_configuration_in, 'sWorkspace_input', sWorkspace_input)
+
+# Set the path to the output folder
+pyflowline_change_json_key_value(sFilename_configuration_in, 'sWorkspace_output', sWorkspace_output)
+
+# Set the model configuration file name
+pyflowline_change_json_key_value(sFilename_configuration_in, 'sFilename_model_configuration', sFilename_configuration_in)
+
+# Set the basin configuration file name
+pyflowline_change_json_key_value(sFilename_configuration_in, 'sFilename_basins', sFilename_basins_in)
+
+# Set the domain boundary file name
+pyflowline_change_json_key_value(sFilename_configuration_in, 'sFilename_mesh_boundary', sFilename_mesh_boundary)
+
+# Note that a DEM can also be supplied. Set the path to the DEM with the sFilename_dem parameter. Although the DEM is not required by `pyflowline`, users will need a DEM to run `hexwatershed`. If a DEM is supplied, a boundary file is not required - the DEM boundary will be used instead. However, if a DEM is not supplied, then the model requires a domain boundary to create the mesh.
+
+# If a boundary file is used, set the iFlag_mesh_boundary flag true
+pyflowline_change_json_key_value(sFilename_configuration_in, 'iFlag_mesh_boundary', 1)
+
+# Set the path to the flowline in the basin configuration file
+pyflowline_change_json_key_value(sFilename_basins_in, 'sFilename_flowline_filter', sFilename_flowline_filter, iFlag_basin_in=1)
+
+#%% read the configuration file to create a pyflowline case
+from pyflowline.configuration.read_configuration_file import pyflowline_read_configuration_file
+oPyflowline = pyflowline_read_configuration_file(sFilename_configuration_in,iCase_index_in=iCase_index, dResolution_meter_in=dResolution_meter, sDate_in=sDate)
+
+#%% change model parameters as needed before running the model
 oPyflowline.aBasin[0].dLatitude_outlet_degree=39.462000
 oPyflowline.aBasin[0].dLongitude_outlet_degree=-76.009300
-oPyflowline.setup()
-oPyflowline.flowline_simplification()
-aCell = oPyflowline.mesh_generation()
-oPyflowline.reconstruct_topological_relationship(aCell)
-oPyflowline.export()
 
+#%% run the model
+oPyflowline.pyflowline_setup()
+oPyflowline.pyflowline_flowline_simplification();
 
-print('Finished')
+#%% generate the mesh. 
+
+# There is currently a bug in the mesh generation function when a boundary file is used instead of a DEM. Skip this step until that bug is fixed.
+
+if iFlag_mesh_generation is True:
+
+    aCell = oPyflowline.pyflowline_mesh_generation();
+    oPyflowline.pyflowline_reconstruct_topological_relationship(aCell)
+
+    # Export the model results for hexwatershed
+    oPyflowline.pyflowline_export()
+    oPyflowline.pyflowline_export_config_to_json()
+    iCase_index= iCase_index+1
+
+else:
+    pass
+
+# %%
+print('Finished lat lon demo.')
+print('Try opening the mesh and flowline files in QGIS for visualization.')
+
+# %%

--- a/examples/susquehanna/run_simulation_mpas.py
+++ b/examples/susquehanna/run_simulation_mpas.py
@@ -127,15 +127,23 @@ oPyflowline.pyflowline_change_model_parameter(
 oPyflowline.aBasin[0].dLatitude_outlet_degree=39.462000
 oPyflowline.aBasin[0].dLongitude_outlet_degree=-76.009300
 
-#%%
+#%% Export the config file after changing parameters
+
+# If desired, the config file can be exported to disk after changing parameters. By default, the configuration files are written to the output folder.
+oPyflowline.pyflowline_export_config_to_json()
+
+#%% Now we can build the flowline 
+
+# Set up the flowlinecase and optionally plot the flowline.
 oPyflowline.pyflowline_setup()
 
-#%%
 if iFlag_visualization == 1:
     oPyflowline.plot(sVariable_in='flowline_filter', sFilename_output_in='filter_flowline.png')
     pass
 
-#%%
+#%% Run the flowline simplification step.
+
+# [see](https://pyflowline.readthedocs.io/en/latest/algorithm/algorithm.html#flowline-simplification)
 if iFlag_simulation == 1:
     oPyflowline.pyflowline_flowline_simplification()
     pass

--- a/examples/susquehanna/run_simulation_mpas.py
+++ b/examples/susquehanna/run_simulation_mpas.py
@@ -1,22 +1,17 @@
 import os, sys
 from pathlib import Path
-
-
-from pyflowline.configuration.read_configuration_file import pyflowline_read_configuration_file
-from pyflowline.configuration.change_json_key_value import pyflowline_change_json_key_value
-from pyflowline.configuration import path_manager as pyflowline_path_manager
-
+from datetime import datetime
 
 #%% Define the case information (configuration file parameters)
+sMesh = 'mpas'
 sRegion = 'susquehanna'
 iCase_index = 1
-iFlag_simulation = 0
+iFlag_simulation = 1
 iFlag_visualization = 1
-sMesh = 'mpas'
-sDate = '20230701'
+sDate = datetime.now().strftime('%Y%m%d')
 
 #%% Define workspace paths and configuration file path parameters
-oPath_parent = pyflowline_path_manager.pyflowline_project_root()
+oPath_parent = Path(__file__).parents[2] # data is located two dir's up
 sys.path.append(str(oPath_parent))
 
 # Define the full path to the input and output folders.
@@ -49,7 +44,7 @@ oFilename_mesh_boundary = oFolder_input.joinpath(
 if os.path.isfile(oFilename_domain_config):
     pass
 else:
-    print('The domain configuration file does not exist: ', oFilename_domain_config)
+    print('The domain configuration file does not exist: \n', oFilename_domain_config)
 
 #%% Update the domain (parent) configuration file
 
@@ -60,6 +55,8 @@ else:
 # 	sFilename_basins: full/path/to/pyflowline_susquehanna_basins.json.
 
 # The json file will be overwritten, you may want to make a copy of it first.
+
+from pyflowline.configuration.change_json_key_value import change_json_key_value as pyflowline_change_json_key_value
 
 # Set the path to the output folder
 # Pass the configuration filename followed by a single key-value pair.
@@ -100,6 +97,8 @@ pyflowline_change_json_key_value(
     iFlag_basin_in=1) # Set iFlag_basin_in=1 when changing the basin configuration file.
 
 #%% Read the configuration file
+from pyflowline.configuration.read_configuration_file import pyflowline_read_configuration_file
+
 oPyflowline = pyflowline_read_configuration_file(
     oFilename_domain_config,
     iCase_index_in=iCase_index,
@@ -130,7 +129,7 @@ oPyflowline.aBasin[0].dLongitude_outlet_degree=-76.009300
 #%% Export the config file after changing parameters
 
 # If desired, the config file can be exported to disk after changing parameters. By default, the configuration files are written to the output folder.
-oPyflowline.pyflowline_export_config_to_json()
+# oPyflowline.pyflowline_export_config_to_json()
 
 #%% Now we can build the flowline 
 
@@ -145,13 +144,13 @@ if iFlag_visualization == 1:
 
 # [see](https://pyflowline.readthedocs.io/en/latest/algorithm/algorithm.html#flowline-simplification)
 if iFlag_simulation == 1:
-    oPyflowline.pyflowline_flowline_simplification()
+    oPyflowline.pyflowline_flowline_simplification();
     pass
 
 #%%
 if iFlag_visualization == 1:
 
-    aExtent_meander = [-76.5, -76.2, 41.6, 41.9]
+    # aExtent_meander = [-76.5, -76.2, 41.6, 41.9]
     # oPyflowline.plot(sVariable_in='flowline_simplified', sFilename_output_in='flowline_simplified.png')
     # oPyflowline.plot(sVariable_in='flowline_simplified',
     #                  sFilename_output_in='flowline_simplified_zoom.png',
@@ -170,14 +169,13 @@ if iFlag_visualization == 1:
 #%%
 if iFlag_simulation == 1:
     oPyflowline.pyflowline_reconstruct_topological_relationship(aCell)
+    # oPyflowline.pyflowline_export()
 
 #%%
 if iFlag_visualization == 1:
     # oPyflowline.plot(sVariable_in='overlap', sFilename_output_in='mesh_w_flowline.png')
     pass
 
-# oPyflowline.pyflowline_export()
-
-print('Finished')
-
 # %%
+print('Finished')
+print('Try opening the mesh and flowline files in QGIS for visualization.')

--- a/examples/susquehanna/run_simulation_square.py
+++ b/examples/susquehanna/run_simulation_square.py
@@ -29,11 +29,11 @@ oPyflowline = pyflowline_read_configuration_file(sFilename_configuration_in, \
 iCase_index_in=iCase_index, dResolution_meter_in=dResolution_meter, sDate_in=sDate)
 oPyflowline.aBasin[0].dLatitude_outlet_degree=39.462000
 oPyflowline.aBasin[0].dLongitude_outlet_degree=-76.009300
-oPyflowline.setup()
-oPyflowline.flowline_simplification()
-aCell = oPyflowline.mesh_generation()
-oPyflowline.reconstruct_topological_relationship(aCell)
-oPyflowline.export()
-
+oPyflowline.pyflowline_setup()
+oPyflowline.pyflowline_flowline_simplification()
+aCell = oPyflowline.pyflowline_mesh_generation()
+oPyflowline.pyflowline_reconstruct_topological_relationship(aCell)
+oPyflowline.pyflowline_export()
+oPyflowline.pyflowline_export_config_to_json()
 
 print('Finished')

--- a/notebooks/mpas_example.ipynb
+++ b/notebooks/mpas_example.ipynb
@@ -35,14 +35,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#step 1\n",
     "import os\n",
     "import sys\n",
     "from pathlib import Path\n",
     "from os.path import realpath\n",
     "import importlib.util\n",
     "import requests\n",
-    "#check dependencies\n"
+    "#check dependencies"
    ]
   },
   {
@@ -55,19 +54,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "a75e5100",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "C:\\workspace\\python\\pyflowline-main\n",
-      "The pyflowline package is not installed. We will use the current path to set it up.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#now add the pyflowline into the Python path.\n",
     "sPath_notebook = Path().resolve()\n",
@@ -95,24 +85,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "c52960d0",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "C:\\workspace\\python\\pyflowline-main\\data\\susquehanna\\input\\mpas_mesh.nc\n",
-      "File 'C:\\workspace\\python\\pyflowline-main\\data\\susquehanna\\input\\mpas_mesh.nc' downloaded successfully.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#download the MPAS mesh from the github release\n",
     "sFilename_mpas = 'https://github.com/changliao1025/pyflowline/releases/download/0.2.0/lnd_cull_mesh.nc'\n",
     "\n",
-    "#combind folder with filename to get the full path\n",
+    "#combine folder with filename to get the full path\n",
     "sFolder_data = os.path.join(sPath_parent, 'data')\n",
     "sFolder_data_susquehanna =  os.path.join(sFolder_data, 'susquehanna')\n",
     "sFolder_input = os.path.join(sFolder_data_susquehanna, 'input')\n",
@@ -153,10 +134,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#step 3\n",
-    "#load the read configuration function\n",
-    "from pyflowline.configuration.change_json_key_value import pyflowline_change_json_key_value\n",
-    "from pyflowline.configuration.read_configuration_file import pyflowline_read_configuration_file"
+    "# Import the read configuration function\n",
+    "from pyflowline.configuration.read_configuration_file import pyflowline_read_configuration_file\n",
+    "from pyflowline.configuration.change_json_key_value import pyflowline_change_json_key_value"
    ]
   },
   {
@@ -166,7 +146,7 @@
    "metadata": {},
    "source": [
     "pyflowline uses a json file for configuration, an example json file is provided.\n",
-    "check whether a configuration exists"
+    "Check whether a configuration exists."
    ]
   },
   {
@@ -176,64 +156,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sFilename_configuration_in = realpath( sPath_parent +  '/data/susquehanna/input/pyflowline_susquehanna_mpas.json' )\n",
+    "sFilename_configuration_in = realpath( sPath_parent + '/data/susquehanna/input/pyflowline_susquehanna_mpas.json' )\n",
     "if os.path.isfile(sFilename_configuration_in):\n",
     "    pass\n",
     "else:\n",
-    "    print('This configuration does not exist: ', sFilename_configuration_in )"
+    "    print('The model configuration file does not exist: \\n', sFilename_configuration_in )"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "394d0745",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\n",
-      "    \"sFilename_model_configuration\": \"/qfs/people/liao313/workspace/python/pyflowline/pyflowline/config/hexwatershed_susquehanna_mpas.json\",\n",
-      "    \"sWorkspace_data\": \"/people/liao313/data\",\n",
-      "    \"sWorkspace_output\": \"/compyfs/liao313/04model/pyflowline/susquehanna\",\n",
-      "    \"sWorkspace_project\": \"/hexwatershed/susquehanna\",\n",
-      "    \"sWorkspace_bin\": \"/people/liao313/bin\",\n",
-      "    \"sRegion\": \"susquehanna\",\n",
-      "    \"sModel\": \"pyflowline\",\n",
-      "    \"sJob\": \"hex\",\n",
-      "    \"iFlag_standalone\": 1,\n",
-      "    \"iFlag_create_mesh\": 1,\n",
-      "    \"iFlag_mesh_boundary\": 1,\n",
-      "    \"iFlag_save_mesh\": 1,\n",
-      "    \"iFlag_simplification\": 1,\n",
-      "    \"iFlag_intersect\": 1,\n",
-      "    \"iFlag_flowline\": 1,\n",
-      "    \"iFlag_use_mesh_dem\": 1,\n",
-      "    \"iFlag_global\": 0,\n",
-      "    \"iFlag_multiple_outlet\": 0,\n",
-      "    \"iFlag_rotation\": 0,\n",
-      "    \"iCase_index\": 1,\n",
-      "    \"iMesh_type\": 4,\n",
-      "    \"dLongitude_left\": -79,\n",
-      "    \"dLongitude_right\": -74.5,\n",
-      "    \"dLatitude_bot\": 39.2,\n",
-      "    \"dLatitude_top\": 42.8,\n",
-      "    \"dResolution_degree\": 5000,\n",
-      "    \"dResolution_meter\": 5000,\n",
-      "    \"sDate\": \"20220110\",\n",
-      "    \"sMesh_type\": \"mpas\",\n",
-      "    \"sFilename_spatial_reference\": \"/qfs/people/liao313/workspace/python/pyhexwatershed_icom/data/susquehanna/input/boundary_proj_buff.shp\",\n",
-      "    \"sFilename_dem\": \"/qfs/people/liao313/workspace/python/pyhexwatershed_icom/data/susquehanna/input/dem_buff_ext.tif\",\n",
-      "    \"sFilename_mesh_netcdf\": \"/qfs/people/liao313/workspace/python/pyflowline/data/susquehanna/input/lnd_cull_mesh.nc\",\n",
-      "    \"sFilename_mesh_boundary\": \"/qfs/people/liao313/workspace/python/pyflowline/data/susquehanna/input/boundary_wgs.geojson\",\n",
-      "    \"sFilename_basins\": \"/qfs/people/liao313/workspace/python/pyflowline/examples/susquehanna/pyflowline_susquehanna_basins.json\"\n",
-      "}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "#we can check what is the content of this json file\n",
+    "#we can check the content of this json file\n",
     "import json\n",
     "with open(sFilename_configuration_in, 'r') as pJSON:\n",
     "    parsed = json.load(pJSON)\n",
@@ -246,9 +183,9 @@
    "id": "85dc3a19",
    "metadata": {},
    "source": [
-    "The meaning of these json keywords are explained in the pyflowline documentation: https://pyflowline.readthedocs.io/en/latest/data/data.html#inputs\n",
+    "The meaning of these json keywords are explained in the [pyflowline documentation](https://pyflowline.readthedocs.io/en/latest/data/data.html#inputs)\n",
     "\n",
-    "For some parameters, we can change them using the following function call.\n",
+    "For some parameters, we can change them using the `pyflowline_change_json_key_value` function call.\n",
     "\n",
     "For some other parameters (e.g., path to file), you need to modify the json file using a text editor.\n",
     "\n",
@@ -261,7 +198,7 @@
    "id": "33cce0f7",
    "metadata": {},
    "source": [
-    "Now set up some keywords"
+    "Now set up some keywords to define parameters in the configuration file."
    ]
   },
   {
@@ -640,7 +577,9 @@
    "id": "e735b614",
    "metadata": {},
    "source": [
-    "now let's run the three major steps/operations one by one."
+    "Now let's run the three major steps/operations one by one.\n",
+    "\n",
+    "Step 1 is [flowline simplification](https://pyflowline.readthedocs.io/en/latest/algorithm/algorithm.html#flowline-simplification)."
    ]
   },
   {
@@ -680,7 +619,6 @@
     }
    ],
    "source": [
-    "#run step 1\n",
     "oPyflowline.pyflowline_flowline_simplification();"
    ]
   },


### PR DESCRIPTION
This pull request updates the demos, focusing on the hexagon and latlon demos following previous updates to the mpas demo. Key updates:

- Fixes the pyflowline package syntax in the model simulation steps near the end of the demos. 
- Adds calls to change_json_key_value for each parameter required to run the hexagon, latlon, and mpas demos. 

The square demo still needs to be updated, but these updates should allow users to run these demos on their local machine without error.